### PR TITLE
Update for latest Rust and Cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 *.so
 *.swp
 *~
+Cargo.lock
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ name = "hamt"
 version = "0.0.1"
 authors = ["Brandon Allard <ballard2626@gmail.com>"]
 
-[[lib]]
+[lib]
 name = "hamt"
 path = "src/lib.rs"

--- a/src/hamt.rs
+++ b/src/hamt.rs
@@ -355,7 +355,7 @@ impl<K: Hash + PartialEq + Clone, V: Clone> HAMT<K,V> {
  * Internal state that defines all vars
  * needed to traverse the HAMT.
  */
-struct SearchState<'a, K> {
+struct SearchState<'a, K: 'a> {
     hash_gen: sip::SipHasher,
     hash_base: u64,
     curr_key: &'a K,
@@ -364,7 +364,7 @@ struct SearchState<'a, K> {
     curr_hsh: u64
 }
 
-impl<'a, K: Hash> SearchState<'a, K> {
+impl<'a, K: Hash + 'a> SearchState<'a, K> {
     #[inline(always)]
     fn new<V>(root: &HAMT<K,V>, key: &'a K) -> SearchState<'a, K> {
         let mut new_state = SearchState {

--- a/src/hp.rs
+++ b/src/hp.rs
@@ -41,6 +41,7 @@ use std::ptr::{mut_null, null};
 use std::cell::RefCell;
 use std::ty::Unsafe;
 use std::io::Timer;
+use std::time::duration::Duration;
 use std::cmp;
 use std::mem;
 
@@ -272,7 +273,9 @@ impl<T> HpInner<T> {
             // Block task exponentially.
             if failures > exp_threshold {
                 let mut timer = Timer::new().unwrap();
-                timer.sleep(1 << ( cmp::min((c*failures), m) / 1000000 ));
+                timer.sleep(
+                    Duration::milliseconds(1 << ( cmp::min((c*failures), m) / 1000000 ))
+                );
             }
             false
         }


### PR DESCRIPTION
Cargo:
- [[lib]] -> [lib]
- Add Cargo.lock to .gitignore

Rust:
- Use new generalized lifetime bounds
- Use Duration instead of int for time.
